### PR TITLE
Update pod related kubectl commands in the tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ To confirm your change has been applied in the cluster, you can connect to the c
  az aks get-credentials --resource-group cft-sbox-00-rg --name cft-sbox-00-aks --subscription DCD-CFTAPPS-SBOX --overwrite-existing
 ```
 
-To make sure your pod is running as expected and to check the status of your HelmRelease run the following command (make sure to swap YourGithubUsername with your GitHub username):
+To make sure your pod is running as expected and to check the status of your HelmRelease run the following commands (make sure to swap YourGithubUsername with your GitHub username):
 
 ```command
 kubectl get hr labs-YourGithubUsername-nodejs -n labs


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23140

### Change description

- Update kubectl command to get pods by the label because the pod label is no longer in "app.kubernetes.io/name: pod" format, it is "app.kubernetes.io/instance: pod" now
- Add couple less specific commands to aid finding the pods if the name is less obvious for some reason

### Testing done
I have run the commands included locally and they work as expected

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
